### PR TITLE
Configure Semaphore to test a Phoenix application

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,23 @@
+version: v1.0
+name: Fishtank
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: mix test
+    task:
+      jobs:
+        - name: mix test
+          commands:
+            - sem-version erlang 22
+            - sem-version elixir master
+            - checkout
+            - mix local.hex --force
+            - mix local.rebar --force
+            - mix deps.get
+            - mix test
+      env_vars:
+        - name: MIX_ENV
+          value: test
+


### PR DESCRIPTION
This minimal configuration is mostly taken from Semaphore's workflow
builder. However, since the default script runs on Elixir 1.9 and OTP
21, and gets stuck installing Hex, this version has some minor
additions.

    version: v1.0
    name: Fishtank
    agent:
      machine:
        type: e1-standard-2
        os_image: ubuntu1804
    blocks:
      - name: mix test
        task:
          jobs:
            - name: mix test
              commands:
                - sem-version erlang 22
                - sem-version elixir master
                - checkout
                - mix local.hex --force
                - mix local.rebar --force
                - mix deps.get
                - mix test
          env_vars:
            - name: MIX_ENV
              value: test

== Elixir and Erlang versions

Semaphore's `sem-version` utility can't install a newer OTP version than
22.1. Any newer version produces a message to install a "valid" version
instead:

    Please provide a valid Erlang version! [20|20.3|21|21.3|22|22.1]

When trying 22.1, the install fails because of a missing directory.

    Changing 'erlang' to version 22.1
    bash: /home/semaphore/.kerl/installs/22.1/activate: No such file or directory

Choosing "22" (`sem-version erlang 22`) fixes the issue, making OTP 22.0
the latest version Semaphore succesfully runs.

It does, however, install the current edge version of Elixir directly
from Github by running `sem-version elixir master`.

== Installing Hex and Rebar

After checking out the project and before isntalling dependencies, the
script runs `mix local.hex --force` and `mix local.rebae --force` to
make sure the run doesn't freeze on the Hex or Rebar installation
prompts:

    mix deps.get
    ==> fishtank_web
    Could not find Hex, which is needed to build dependency :phoenix_html
    Shall I ins

    mix test
    Could not find "rebar3", which is needed to build dependency :ranch
    I can install a local copy which is just used by Mix
    Shall I install rebar3? (if running non-interactively, use "mix local.rebar -