### PR TITLE
Resolve CVE 2020-7598 by updating Webpack to 4.42.0 

### DIFF
--- a/apps/fishtank_web/assets/package-lock.json
+++ b/apps/fishtank_web/assets/package-lock.json
@@ -3046,9 +3046,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
-      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+      "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -3102,7 +3102,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.3",
+          "version": "1.1.4",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3274,7 +3274,7 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
+          "version": "1.2.5",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3299,12 +3299,12 @@
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
+          "version": "0.5.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
@@ -3314,7 +3314,7 @@
           "optional": true
         },
         "needle": {
-          "version": "2.4.0",
+          "version": "2.3.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3343,7 +3343,7 @@
           }
         },
         "nopt": {
-          "version": "4.0.1",
+          "version": "4.0.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3368,13 +3368,14 @@
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.7",
+          "version": "1.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "npm-bundled": "^1.0.1",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npmlog": {
@@ -3454,18 +3455,10 @@
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
           }
         },
         "readable-stream": {
-          "version": "2.3.6",
+          "version": "2.3.7",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -6886,9 +6879,9 @@
       }
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
       "dev": true
     },
     "tty-browserify": {
@@ -7135,9 +7128,9 @@
       }
     },
     "webpack": {
-      "version": "4.41.5",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.5.tgz",
-      "integrity": "sha512-wp0Co4vpyumnp3KlkmpM5LWuzvZYayDwM2n17EHFr4qxBBbRokC7DJawPJC7TfSFZ9HZ6GsdH40EBj4UV0nmpw==",
+      "version": "4.42.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.42.0.tgz",
+      "integrity": "sha512-EzJRHvwQyBiYrYqhyjW9AqM90dE4+s1/XtCfn7uWg6cS72zH+2VPFAlsnW0+W0cDi0XRjNKUMoJtpSi50+Ph6w==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",

--- a/apps/fishtank_web/assets/package.json
+++ b/apps/fishtank_web/assets/package.json
@@ -19,7 +19,7 @@
     "mini-css-extract-plugin": "^0.9.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "terser-webpack-plugin": "^2.3.5",
-    "webpack": "4.41.5",
+    "webpack": "4.42.0",
     "webpack-cli": "^3.3.11"
   }
 }


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7598[CVE 2020-7598] is
a vulnerability in the `minimist` package, which is a dependency in Phoenix
applications through the `mkdirp` and `rc` packages. Both are in Webpack's
dependency tree.

    $ npm audit --prefix=apps/fishtank_web/assets

                          === npm audit security report ===

    ┌──────────────────────────────────────────────────────────────────────────────┐
    │                                Manual Review                                 │
    │            Some vulnerabilities require your attention to resolve            │
    │                                                                              │
    │         Visit https://go.npm.me/audit-guide for additional guidance          │
    └──────────────────────────────────────────────────────────────────────────────┘
    ┌───────────────┬──────────────────────────────────────────────────────────────┐
    │ Low           │ Prototype Pollution                                          │
    ├───────────────┼──────────────────────────────────────────────────────────────┤
    │ Package       │ minimist                                                     │
    ├───────────────┼──────────────────────────────────────────────────────────────┤
    │ Patched in    │ >=0.2.1 <1.0.0 || >=1.2.3                                    │
    ├───────────────┼──────────────────────────────────────────────────────────────┤
    │ Dependency of │ webpack [dev]                                                │
    ├───────────────┼──────────────────────────────────────────────────────────────┤
    │ Path          │ webpack > watchpack > chokidar > fsevents > node-pre-gyp >   │
    │               │ mkdirp > minimist                                            │
    ├───────────────┼──────────────────────────────────────────────────────────────┤
    │ More info     │ https://npmjs.com/advisories/1179                            │
    └───────────────┴──────────────────────────────────────────────────────────────┘
    ┌───────────────┬──────────────────────────────────────────────────────────────┐
    │ Low           │ Prototype Pollution                                          │
    ├───────────────┼──────────────────────────────────────────────────────────────┤
    │ Package       │ minimist                                                     │
    ├───────────────┼──────────────────────────────────────────────────────────────┤
    │ Patched in    │ >=0.2.1 <1.0.0 || >=1.2.3                                    │
    ├───────────────┼──────────────────────────────────────────────────────────────┤
    │ Dependency of │ webpack [dev]                                                │
    ├───────────────┼──────────────────────────────────────────────────────────────┤
    │ Path          │ webpack > watchpack > chokidar > fsevents > node-pre-gyp >   │
    │               │ tar > mkdirp > minimist                                      │
    ├───────────────┼──────────────────────────────────────────────────────────────┤
    │ More info     │ https://npmjs.com/advisories/1179                            │
    └───────────────┴──────────────────────────────────────────────────────────────┘
    ┌───────────────┬──────────────────────────────────────────────────────────────┐
    │ Low           │ Prototype Pollution                                          │
    ├───────────────┼──────────────────────────────────────────────────────────────┤
    │ Package       │ minimist                                                     │
    ├───────────────┼──────────────────────────────────────────────────────────────┤
    │ Patched in    │ >=0.2.1 <1.0.0 || >=1.2.3                                    │
    ├───────────────┼──────────────────────────────────────────────────────────────┤
    │ Dependency of │ webpack [dev]                                                │
    ├───────────────┼──────────────────────────────────────────────────────────────┤
    │ Path          │ webpack > watchpack > chokidar > fsevents > node-pre-gyp >   │
    │               │ rc > minimist                                                │
    ├───────────────┼──────────────────────────────────────────────────────────────┤
    │ More info     │ https://npmjs.com/advisories/1179                            │
    └───────────────┴──────────────────────────────────────────────────────────────┘
    found 3 low severity vulnerabilities in 8589 scanned packages
      3 vulnerabilities require manual review. See the full report for details.

It can't be fixed by running `npm audit fix`, as newly generated Phoenix
projects depend on Webpack "4.41.5", which depends on `mkdirp` version
0.5.1. That version depends `minimist` 0.0.8, which is vulnerable.

Upgrading Webpack to 4.42.0 resolves the issue, as that version requires
`mkdirp` 0.5.3, which depends on `minimist` 1.2.5 or higher.

```js
# apps/fishtank_web/assets/package.json
{
  "repository": {},
  "description": " ",
  "license": "MIT",
  "scripts": {
    "deploy": "webpack --mode production",
    "watch": "webpack --mode development --watch"
  },
  "dependencies": {
    "phoenix": "file:../../../deps/phoenix",
    "phoenix_html": "file:../../../deps/phoenix_html"
  },
  "devDependencies": {
    "@babel/core": "^7.9.0",
    "@babel/preset-env": "^7.9.0",
    "babel-loader": "^8.1.0",
    "copy-webpack-plugin": "^5.1.1",
    "css-loader": "^3.4.2",
    "mini-css-extract-plugin": "^0.9.0",
    "optimize-css-assets-webpack-plugin": "^5.0.1",
    "terser-webpack-plugin": "^2.3.5",
    "webpack": "4.42.0",
    "webpack-cli": "^3.3.11"
  }
}
```

    $ npm install --prefix=apps/fishtank_web/assets
    audited 8590 packages in 7.224s

    found 0 vulnerabilities