### PR TITLE
Run `npm audit` to test for vulnerabilities on CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,6 +8,10 @@ blocks:
   - name: mix test
     task:
       jobs:
+        - name: npm audit
+          commands:
+            - checkout
+            - npm audit --prefix=apps/fishtank_web/assets
         - name: mix test
           commands:
             - sem-version erlang 22


### PR DESCRIPTION
To make sure CI runs fail when a project depends on a npm project with
known secutiry vulnerabilities, run npm's `audit` command in one of the
test suite's checks.

In a Phoenix project on Semaphore, add a separate job that checks out
the project and runs `npm audit`, with the `--prefix` option pointing to
the directory containing the `package-lock.json` file.

    version: v1.0
    name: Fishtank
    agent:
      machine:
        type: e1-standard-2
        os_image: ubuntu1804
    blocks:
      - name: mix test
        task:
          jobs:
            - name: npm audit
              commands:
                - checkout
                - npm audit --prefix=apps/fishtank_web/assets
            - name: mix test
              commands:
                - sem-version erlang 22
                - sem-version elixir master
                - checkout
                - mix local.hex --force
                - mix local.rebar --force
                - mix deps.get
                - mix test
          env_vars:
            - name: MIX_ENV
              value: test

Since `npm audit` returns a non-zero exit code on failure, the job
automatically fails when npm finds any vulnerabilities in the project's
dependencies.